### PR TITLE
Make AUFS commentary optional.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,5 @@ RUN	echo swift:fingertips | chpasswd; usermod -a -G sudo swift
 
 RUN echo %sudo	ALL=NOPASSWD: ALL >> /etc/sudoers
 
-VOLUME	/swift/nodes
-
 EXPOSE 8080
 CMD ["/bin/bash", "/swift/bin/launch.sh"]


### PR DESCRIPTION
As overlay2 is now a common storage driver and AUFS is deprecated, the
docker-swift container no longer has to have an external volume and can
rely on Docker storage.