### PR TITLE
Upgrade to Swift 2.20.0 and swiftclient 3.6.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y --no-install-recommends git-core && \
-    git clone --branch 3.5.0 --single-branch --depth 1 https://github.com/openstack/python-swiftclient.git /usr/local/src/python-swiftclient && \
+    git clone --branch 3.6.0 --single-branch --depth 1 https://github.com/openstack/python-swiftclient.git /usr/local/src/python-swiftclient && \
     cd /usr/local/src/python-swiftclient && python setup.py develop && \
-    git clone --branch 2.19.0 --single-branch --depth 1 https://github.com/openstack/swift.git /usr/local/src/swift && \
+    git clone --branch 2.20.0 --single-branch --depth 1 https://github.com/openstack/swift.git /usr/local/src/swift && \
     cd /usr/local/src/swift && python setup.py develop && \
-    git clone --branch 1.12 --single-branch --depth 1 https://github.com/openstack/swift3.git /usr/local/src/swift3 && \
-    cd /usr/local/src/swift3 && python setup.py develop && \
     apt-get remove -y --purge git-core git && \
     apt-get autoremove -y --purge && \
     apt-get clean && \

--- a/swift/proxy-server.conf
+++ b/swift/proxy-server.conf
@@ -7,7 +7,7 @@ eventlet_debug = true
 
 [pipeline:main]
 # Yes, proxy-logging appears twice. This is not a mistake.
-pipeline = healthcheck proxy-logging cache swift3 bulk tempurl tempauth versioned_writes slo dlo symlink proxy-logging proxy-server
+pipeline = healthcheck proxy-logging cache s3api bulk tempurl tempauth versioned_writes slo dlo symlink proxy-logging proxy-server
 
 [app:proxy-server]
 use = egg:swift#proxy
@@ -72,5 +72,5 @@ use = egg:swift#dlo
 [filter:symlink]
 use = egg:swift#symlink
 
-[filter:swift3]
-use = egg:swift3#swift3
+[filter:s3api]
+use = egg:swift#s3api


### PR DESCRIPTION
Removes the swift3 dependency, as it is now shipped with Swift as s3api.